### PR TITLE
Add support for multiple examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,29 @@ describe 'Blogs API' do
 end
 ```
 
+Multiple examples are supported by wrapping the example in an array, and supplying an example name:
+
+```ruby
+# spec/integration/blogs_spec.rb
+describe 'Blogs API' do
+
+  path '/blogs/{blog_id}' do
+
+    get 'Retrieves a blog' do
+
+      response 200, 'blog found' do
+        examples 'application/json' => [
+            'First example' => {
+                id: 1,
+                title: 'Hello world!',
+                content: '...'
+            },
+            'Second example' => { ... }
+        ]
+  ...
+end
+```
+
 
 ### Enable auto generation examples from responses ###
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/deep_merge'
+
 module Rswag
   module Specs
     module ExampleGroupHelpers
@@ -72,10 +74,19 @@ module Rswag
       def examples(example = nil)
         return super() if example.nil?
 
-        metadata[:response][:content] =
+        metadata[:response][:content] ||= {}
+
+        metadata[:response][:content].deep_merge!(
           example.each_with_object({}) do |(mime, example_object), memo|
-            memo[mime] = { example: example_object }
+            memo[mime] ||= {}
+            if example_object.is_a?(Hash)
+              memo[mime][:example] = example_object
+            else
+              memo[mime][:examples] ||= {}
+              memo[mime][:examples].merge! example_object.first
+            end
           end
+        )
       end
 
       def run_test!(&block)

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -145,18 +145,65 @@ module Rswag
             }
           }
         end
+        let(:json_examples) do
+          {
+            mime => [{
+                       foobar: { foo: 'bar' },
+                       barfoo: { foo: 'bat' }
+                     }]
+          }
+        end
+        let(:json_examples_two) do
+          {
+            mime => [{
+              foobat: { foo: 'bat' },
+            }]
+          }
+        end
         let(:api_metadata) { { response: {} } }
 
-        before do
-          subject.examples(json_example)
+        context "when there is one example" do
+          before { subject.examples(json_example) }
+
+          it "adds to the 'response examples' metadata" do
+            expect(api_metadata[:response][:content]).to match(
+              mime => {
+                example: { foo: 'bar' }
+              }
+            )
+          end
         end
 
-        it "adds to the 'response examples' metadata" do
-          expect(api_metadata[:response][:content]).to match(
-            mime => {
-              example: json_example[mime]
-            }
-          )
+        context "when there are multiple examples" do
+          before { subject.examples(json_examples) }
+
+          it "adds to the 'response examples' metadata" do
+            expect(api_metadata[:response][:content]).to match(
+              mime => {
+                examples: {
+                  foobar: { foo: 'bar' },
+                  barfoo: { foo: 'bat' }
+                }
+              }
+            )
+          end
+        end
+
+        context "when there are multiple invocations" do
+          before { subject.examples(json_examples) }
+          before { subject.examples(json_examples_two) }
+
+          it "adds to the 'response examples' metadata" do
+            expect(api_metadata[:response][:content]).to match(
+              mime => {
+                examples: {
+                  foobar: { foo: 'bar' },
+                  barfoo: { foo: 'bat' },
+                 foobat: { foo: 'bat' }
+                }
+              }
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Add support for multiple examples by utilizing the `examples` key instead of `example`. This also has the benefit of supporting `$ref` in examples, as the spec only allows them on `examples`.

Single example syntax doesn't change:

```ruby
examples 'application/json' => {
  id: 1,
  title: 'Hello world!',
  content: '...'
}
```

Multiple examples have to be wrapped in an array:

```ruby
examples 'application/json' => [
  'First example' => {
    id: 1,
    title: 'Hello world!',
    content: '...'
  },
  'Second example' => { ... }
]
```